### PR TITLE
Add validation check for directive arguments

### DIFF
--- a/validator/schema.go
+++ b/validator/schema.go
@@ -293,6 +293,15 @@ func validateDirectives(schema *Schema, dirs DirectiveList, currentDirective *Di
 		if schema.Directives[dir.Name] == nil {
 			return gqlerror.ErrorPosf(dir.Position, "Undefined directive %s.", dir.Name)
 		}
+		argMap := make(map[string]int)
+		for i, arg := range schema.Directives[dir.Name].Arguments {
+			argMap[arg.Name] = i
+		}
+		for _, arg := range dir.Arguments {
+			if _, ok := argMap[arg.Name]; !ok {
+				return gqlerror.ErrorPosf(dir.Position, "Argument %s is not valid for directive %s", arg.Name, dir.Name)
+			}
+		}
 		dir.Definition = schema.Directives[dir.Name]
 	}
 	return nil

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -521,6 +521,23 @@ directives:
       input I1 @inp { f: String }
       type P { name: String @test }
 
+  - name: Invalid directive argument not allowed
+    input: |
+      directive @foo(bla: Int!) on FIELD_DEFINITION
+      type P {f: Int @foo(foobla: 11)}
+    
+    error:
+      message: 'Undefined argument foobla for directive foo.'
+      locations: [{line: 2, column: 17}]
+
+  - name: Nil value not allowed for non-null types
+    input: |
+      directive @foo(bla: Int!) on FIELD_DEFINITION
+      type P {f: Int @foo }
+    
+    error:
+      message: 'Argument bla for directive foo cannot be null.'
+      locations: [{line: 2, column: 17}]
 
 entry points:
   - name: multiple schema entry points


### PR DESCRIPTION
Adds a validation for directive arguments. The arguments for the directives are now checked against the defined arguments. For example, if the directive is defined as:
```
directive @foo(bla: Int!) on FIELD_DEFINITION
``` 
then defining a type with directive with unknown argument like below will not be valid:
```
type P {
  g: Int @foo(nobla: 152)
}
```
Fixes: https://github.com/vektah/gqlparser/issues/107
