### PR TITLE
fix(GraphQL):Add input coercion to string for ID types.

### DIFF
--- a/validator/testdata/vars.graphql
+++ b/validator/testdata/vars.graphql
@@ -10,6 +10,7 @@ type Query {
     defaultStructArg(i: InputType! = {name: "foo"}): Boolean!
     arrayArg(i: [InputType!]): Boolean!
     intArrayArg(i: [Int]): Boolean!
+    idArrayArg(i: [ID]): Boolean!
     stringArrayArg(i: [String]): Boolean!
     boolArrayArg(i: [Boolean]): Boolean!
     typeArrayArg(i: [CustomType]): Boolean!

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -76,15 +76,20 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) (reflec
 		v.path = currentPath
 	}
 	defer resetPath()
+	slc := make([]interface{}, 0)
 	if typ.Elem != nil {
 		if val.Kind() != reflect.Slice {
 			// GraphQL spec says that non-null values should be coerced to an array when possible.
 			// Hence if the value is not a slice, we create a slice and add val to it.
-			slc := make([]interface{}, 0)
-			slc = append(slc, val.Interface())
+			if typ.Name() == "ID" {
+				val = val.Convert((reflect.ValueOf("string")).Type())
+				slc = append(slc, val.String())
+			} else {
+				slc = append(slc, val.Interface())
+			}
 			val = reflect.ValueOf(slc)
-			val.Convert(val.Type())
 		}
+		slc = []interface{}{}
 		for i := 0; i < val.Len(); i++ {
 			resetPath()
 			v.path = append(v.path, ast.PathIndex(i))
@@ -95,10 +100,17 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) (reflec
 				}
 				field = field.Elem()
 			}
-			_, err := v.validateVarType(typ.Elem, field)
+			cVal, err := v.validateVarType(typ.Elem, field)
+			if typ.Name() == "ID" {
+				cVal = cVal.Convert((reflect.ValueOf("string")).Type())
+				slc = append(slc, cVal.String())
+			}
 			if err != nil {
 				return val, err
 			}
+		}
+		if typ.Name() == "ID" {
+			val = reflect.ValueOf(slc)
 		}
 		return val, nil
 	}
@@ -151,6 +163,7 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) (reflec
 
 		case "ID":
 			if kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 || kind == reflect.String {
+				val = val.Convert((reflect.ValueOf("string")).Type())
 				return val, nil
 			}
 		default:
@@ -204,11 +217,11 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) (reflec
 				}
 				field = field.Elem()
 			}
-			cval, err := v.validateVarType(fieldDef.Type, field)
+			cVal, err := v.validateVarType(fieldDef.Type, field)
 			if err != nil {
 				return val, err
 			}
-			val.SetMapIndex(reflect.ValueOf(fieldDef.Name), cval)
+			val.SetMapIndex(reflect.ValueOf(fieldDef.Name), cVal)
 		}
 	default:
 		panic(fmt.Errorf("unsupported type %s", def.Kind))

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -170,6 +170,26 @@ func TestValidateVars(t *testing.T) {
 			require.EqualValues(t, expected, vars["var"])
 		})
 
+		t.Run("int value should be coerced to string array when required type is [ID]", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: [ID]) { idArrayArg(i: $var) }`)
+			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": 5,
+			})
+			require.Nil(t, gerr)
+			expected := []interface{}{"\x05"}
+			require.EqualValues(t, expected, vars["var"])
+		})
+
+		t.Run("int array should be coerced to string array when required type is [ID]", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: [ID]) { idArrayArg(i: $var) }`)
+			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": []interface{}{5, 6},
+			})
+			require.Nil(t, gerr)
+			expected := []interface{}{"\x05", "\x06"}
+			require.EqualValues(t, expected, vars["var"])
+		})
+
 		t.Run("non-null int deep value should be coerced to an array", func(t *testing.T) {
 			q := gqlparser.MustLoadQuery(schema, `query foo($var: [CustomType]) { typeArrayArg(i: $var) }`)
 			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -200,6 +200,16 @@ func TestValidateVars(t *testing.T) {
 			require.EqualValues(t, expected, vars["var"])
 		})
 
+		t.Run("int value will be converted to string when required type is ID", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: ID!) { idArg(i: $var) }`)
+			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": 5,
+			})
+			require.Nil(t, gerr)
+			expected := "\x05"
+			require.EqualValues(t, expected, vars["var"])
+		})
+
 		t.Run("defaults", func(t *testing.T) {
 			q := gqlparser.MustLoadQuery(schema, `query foo($var: [InputType!] = [{name: "foo"}]) { arrayArg(i: $var) }`)
 			vars, gerr := validator.VariableValues(schema, q.Operations.ForName(""), nil)


### PR DESCRIPTION
The following query was giving panic because here we passed ID as an int which is expected to be a string.

```
query allStories {
      queryUser(filter: {
        id: 22
      }) {
        stories {
          id
          text
        }
      }
    }

```

We now added input coercion so that the ID type value will be coerced to string type. And if we give a slice of integer values or the required type is [ID] then that will be coerced to slice of integer values.