### PR TITLE
fix(GraphQL): Added validation for parameterized cascade arguments passed through variables.

### DIFF
--- a/gqlparser.go
+++ b/gqlparser.go
@@ -25,7 +25,7 @@ func LoadQuery(schema *ast.Schema, str string) (*ast.QueryDocument, gqlerror.Lis
 	if err != nil {
 		return nil, gqlerror.List{err}
 	}
-	errs := validator.Validate(schema, query)
+	errs := validator.Validate(schema, query, nil)
 	if errs != nil {
 		return nil, errs
 	}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -22,7 +22,7 @@ func AddRule(name string, f ruleFunc) {
 	rules = append(rules, rule{name: name, rule: f})
 }
 
-func Validate(schema *Schema, doc *QueryDocument) gqlerror.List {
+func Validate(schema *Schema, doc *QueryDocument, variables map[string]interface{}) gqlerror.List {
 	var errs gqlerror.List
 
 	observers := &Events{}
@@ -39,6 +39,6 @@ func Validate(schema *Schema, doc *QueryDocument) gqlerror.List {
 		})
 	}
 
-	Walk(schema, doc, observers)
+	Walk(schema, doc, observers, variables)
 	return errs
 }

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -37,5 +37,5 @@ extend type Query {
 		}
 	}`})
 	require.Nil(t, err)
-	require.Nil(t, validator.Validate(s, q))
+	require.Nil(t, validator.Validate(s, q, nil))
 }

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -3,11 +3,12 @@ package validator
 import (
 	"errors"
 	"fmt"
-	"github.com/dgraph-io/gqlparser/v2/ast"
-	"github.com/dgraph-io/gqlparser/v2/gqlerror"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/dgraph-io/gqlparser/v2/ast"
+	"github.com/dgraph-io/gqlparser/v2/gqlerror"
 )
 
 // VariableValues coerces and validates variable values

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -64,62 +64,7 @@ func VariableValues(schema *ast.Schema, op *ast.OperationDefinition, variables m
 
 		validator.path = validator.path[0 : len(validator.path)-1]
 	}
-	// cascade directive arguments validation
-	if op.VariableDefinitions != nil {
-		err := validator.cascadeDirectiveValidation(op, op.SelectionSet, variables)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return coercedVars, nil
-}
-
-func (v *varValidator) cascadeDirectiveValidation(op *ast.OperationDefinition, sel ast.SelectionSet, variables map[string]interface{}) *gqlerror.Error {
-
-	for _, s := range sel {
-		if f, ok := s.(*ast.Field); ok {
-			cascadedir := f.Directives.ForName("cascade")
-			if cascadedir == nil {
-				continue
-			}
-			if len(cascadedir.Arguments) == 1 {
-				if cascadedir.ParentDefinition == nil {
-					return gqlerror.Errorf("Schema is not set yet. Please try after sometime.")
-				}
-			}
-			if cascadedir.Arguments.ForName("fields") == nil {
-				continue
-			}
-			fieldArg := cascadedir.Arguments.ForName("fields")
-			isVariable := strings.HasPrefix(fieldArg.Value.String(), "$")
-			if !isVariable {
-				continue
-			}
-
-			varName := op.VariableDefinitions.ForName(cascadedir.Arguments.ForName("fields").Value.Raw)
-			v.path = append(v.path, ast.PathName(varName.Variable))
-			if cascadedir.ArgumentMap(variables)["fields"] == nil {
-				return gqlerror.ErrorPathf(v.path, "variable %s not defined", varName.Variable)
-			}
-
-			variableVal := cascadedir.ArgumentMap(variables)["fields"].([]interface{})
-			typFields := cascadedir.ParentDefinition.Fields
-			typName := cascadedir.ParentDefinition.Name
-			for _, val := range variableVal {
-				if typFields.ForName(val.(string)) == nil {
-					v.path = append(v.path, ast.PathName(val.(string)))
-					return gqlerror.ErrorPathf(v.path, "Field `%s` is not present in type `%s`."+
-						" You can only use fields which are in type `%s`", val, typName, typName)
-				}
-			}
-			v.path = v.path[0 : len(v.path)-1]
-			err := v.cascadeDirectiveValidation(op, f.SelectionSet, variables)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 type varValidator struct {

--- a/validator/vars.go
+++ b/validator/vars.go
@@ -58,7 +58,6 @@ func VariableValues(schema *ast.Schema, op *ast.OperationDefinition, variables m
 					return nil, err
 				}
 				coercedVars[v.Variable] = rval.Interface()
-
 			}
 		}
 

--- a/validator/walk.go
+++ b/validator/walk.go
@@ -43,22 +43,23 @@ func (o *Events) OnValue(f func(walker *Walker, value *ast.Value)) {
 	o.value = append(o.value, f)
 }
 
-func Walk(schema *ast.Schema, document *ast.QueryDocument, observers *Events) {
+func Walk(schema *ast.Schema, document *ast.QueryDocument, observers *Events, variables map[string]interface{}) {
 	w := Walker{
 		Observers: observers,
 		Schema:    schema,
 		Document:  document,
+		Variables: variables,
 	}
 
 	w.walk()
 }
 
 type Walker struct {
-	Context   context.Context
-	Observers *Events
-	Schema    *ast.Schema
-	Document  *ast.QueryDocument
-
+	Context                  context.Context
+	Observers                *Events
+	Schema                   *ast.Schema
+	Document                 *ast.QueryDocument
+	Variables                map[string]interface{}
 	validatedFragmentSpreads map[string]bool
 	CurrentOperation         *ast.OperationDefinition
 }

--- a/validator/walk_test.go
+++ b/validator/walk_test.go
@@ -25,7 +25,7 @@ func TestWalker(t *testing.T) {
 		require.Equal(t, "Query", field.ObjectDefinition.Name)
 	})
 
-	Walk(schema, query, observers)
+	Walk(schema, query, observers, nil)
 
 	require.True(t, called)
 }
@@ -46,7 +46,7 @@ func TestWalkInlineFragment(t *testing.T) {
 		require.Equal(t, "Query", field.ObjectDefinition.Name)
 	})
 
-	Walk(schema, query, observers)
+	Walk(schema, query, observers, nil)
 
 	require.True(t, called)
 }


### PR DESCRIPTION
Fixes: GRAPHQL-1007
We have allowed to paas @cascade arguments through variables in dgraph. For that we needed input validations check which is added in this library. 