### PR TITLE
[Breaking] fix(GraphQL): fix validation when we give non-string value in variable and expected type is string.

### DIFF
--- a/validator/vars.go
+++ b/validator/vars.go
@@ -145,6 +145,7 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) (reflec
 		return val, nil
 	case ast.Scalar:
 		kind := val.Type().Kind()
+		namedType := val.Type().Name()
 		switch typ.NamedType {
 		case "Int", "Int64":
 			if kind == reflect.String || kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
@@ -176,7 +177,7 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) (reflec
 				return val, nil
 			}
 		case "String":
-			if kind == reflect.String {
+			if namedType == "string" {
 				return val, nil
 			}
 

--- a/validator/walk.go
+++ b/validator/walk.go
@@ -59,7 +59,7 @@ type Walker struct {
 	Observers                *Events
 	Schema                   *ast.Schema
 	Document                 *ast.QueryDocument
-	Variables                map[string]interface{}
+	Variables                map[string]interface{} // These variables are not coerced
 	validatedFragmentSpreads map[string]bool
 	CurrentOperation         *ast.OperationDefinition
 }


### PR DESCRIPTION
When we give variables in a request, then those are unmarshaled in dgraph code where any Int or Float is unmarshaled to `json.Number`.

While validating in gqlParser library we were checking `Type.Kind()` of these variables which is still `string`. So, we were not generating any error  if we give ` Int` or `Float ` value and expected type is `string`. That is a bug and in our dgraph code it is giving  a panic because we expected a string value but sometimes got `Int` or `Float`.

So now instead of `Type.Kind()` we compare `Type().Name()` of variable which will give `Number` if given variable is `Int or Float`.

This change will also make our implementation Graphql spec complaint.
