### PR TITLE
[Breaking] fix(GRAPHQL): Remove support of String --> int32 coercion in variables.

### DIFF
--- a/validator/vars.go
+++ b/validator/vars.go
@@ -148,7 +148,7 @@ func (v *varValidator) validateVarType(typ *ast.Type, val reflect.Value) (reflec
 		namedType := val.Type().Name()
 		switch typ.NamedType {
 		case "Int", "Int64":
-			if kind == reflect.String || kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 {
+			if kind == reflect.Int || kind == reflect.Int32 || kind == reflect.Int64 || (namedType == "string" && typ.NamedType == "Int64") || namedType == "Number" {
 				var errIntCoerce error
 				var valString string
 				if kind == reflect.String {

--- a/validator/vars_test.go
+++ b/validator/vars_test.go
@@ -343,6 +343,14 @@ func TestValidateVars(t *testing.T) {
 			require.EqualError(t, gerr, "input: variable.var cannot use float64 as Int")
 		})
 
+		t.Run("error for invalid coercing, String -> Int ", func(t *testing.T) {
+			q := gqlparser.MustLoadQuery(schema, `query foo($var: Int!) { intArg(i: $var) }`)
+			_, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{
+				"var": "18",
+			})
+			require.EqualError(t, gerr, "input: variable.var cannot use string as Int")
+		})
+
 		t.Run("out of range error for Int", func(t *testing.T) {
 			q := gqlparser.MustLoadQuery(schema, `query foo($var: Int!) { intArg(i: $var) }`)
 			_, gerr := validator.VariableValues(schema, q.Operations.ForName(""), map[string]interface{}{


### PR DESCRIPTION
According to graphql specs, any value apart from `Int` should return an error if passed to a variable whose expected type is  int32.
We are  removing support for `String --> Int32` coercing, though for int64 we still support `String -->Int64` coercing when values are passed as variables.