### PR TITLE
fix(Parser): Add directive argument validator

### DIFF
--- a/validator/schema.go
+++ b/validator/schema.go
@@ -290,14 +290,14 @@ func validateArgs(schema *Schema, args ArgumentDefinitionList, currentDirective 
 }
 
 func validateDirectiveArgs(dir *Directive, schema *Schema) *gqlerror.Error {
-	allowedArgs := make(map[string]struct{}, len(schema.Directives[dir.Name].Arguments))
+	allowedArgs := make(map[string]struct{})
 	for _, arg := range schema.Directives[dir.Name].Arguments {
 		allowedArgs[arg.Name] = struct{}{}
 	}
 
 	for _, arg := range dir.Arguments {
 		if _, ok := allowedArgs[arg.Name]; !ok {
-			return gqlerror.Errorf("%s is not supported as an argument for %s directive.", arg.Name, dir.Name)
+			return gqlerror.ErrorPosf(dir.Position, "%s is not supported as an argument for %s directive.", arg.Name, dir.Name)
 		}
 	}
 	return nil
@@ -310,14 +310,14 @@ func validateDirectives(schema *Schema, dirs DirectiveList, location DirectiveLo
 			// now, GraphQL spec doesn't have reserved directive name
 			return err
 		}
-		if err := validateDirectiveArgs(dir, schema); err != nil {
-			return err
-		}
 		if currentDirective != nil && dir.Name == currentDirective.Name {
 			return gqlerror.ErrorPosf(dir.Position, "Directive %s cannot refer to itself.", currentDirective.Name)
 		}
 		if schema.Directives[dir.Name] == nil {
 			return gqlerror.ErrorPosf(dir.Position, "Undefined directive %s.", dir.Name)
+		}
+		if err := validateDirectiveArgs(dir, schema); err != nil {
+			return err
 		}
 		validKind := false
 		for _, dirLocation := range schema.Directives[dir.Name].Locations {

--- a/validator/schema_test.yml
+++ b/validator/schema_test.yml
@@ -505,6 +505,16 @@ directives:
 
       directive @A(a: Input, b: Scalar, c: Enum) on FIELD_DEFINITION
 
+  - name: Valid arg for directive
+    input: |
+      type User @include(aggregate: false) {
+        name: String
+      }
+
+    error:
+      message: 'aggregate is not supported as an argument for include directive.'
+      locations: [{line: 1, column: 12}]
+
   - name: Objects not allowed
     input: |
       type Object { id: ID }


### PR DESCRIPTION
Before this fix, the library didn't validate arguments to the directives. This fix adds the validation and appropriate error handling. 

